### PR TITLE
Add basic Python assistant MVP

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pycryptodome
+transformers
+torch

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,11 @@
 import React from 'react';
+import Chat from '@/components/Chat';
 
 const HomePage: React.FC = () => {
   return (
     <div>
       <h1>Bienvenue sur Privus</h1>
+      <Chat />
     </div>
   );
 };

--- a/src/assistant/assistant.py
+++ b/src/assistant/assistant.py
@@ -1,0 +1,55 @@
+import os
+import datetime
+from pathlib import Path
+from .crypto_utils import generate_key
+from .database import Database
+from .nlp import parse_command
+
+DATA_DIR = Path(os.environ.get("PRIVUS_DATA", "data"))
+DB_PATH = DATA_DIR / "assistant.db"
+
+
+def main():
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    key = generate_key()
+    db = Database(DB_PATH, key)
+
+    print("Assistant personnel Privus. Tapez 'exit' pour quitter.")
+    while True:
+        try:
+            command = input(">>> ")
+        except EOFError:
+            break
+        if command.strip().lower() in {"exit", "quit"}:
+            break
+        action = parse_command(command)
+        if not action:
+            print("Je n'ai pas compris la commande.")
+            continue
+
+        name, params = action
+        if name == "view_events_tomorrow":
+            date = datetime.date.today() + datetime.timedelta(days=1)
+            events = db.get_events_for_day(date)
+            if not events:
+                print("Aucun événement prévu pour demain.")
+            else:
+                for ev in events:
+                    print(f"- {ev['title']} à {ev['datetime'].strftime('%Hh%M')}")
+        elif name == "add_event_tomorrow":
+            hour = params["hour"]
+            date = datetime.date.today() + datetime.timedelta(days=1)
+            dt = datetime.datetime.combine(date, datetime.time(hour=hour))
+            db.add_event("Rendez-vous", dt)
+            print("Rendez-vous ajouté.")
+        elif name == "add_reminder_today":
+            hour = params["hour"]
+            note = params["note"]
+            date = datetime.date.today()
+            dt = datetime.datetime.combine(date, datetime.time(hour=hour))
+            db.add_event(f"Rappel: {note}", dt)
+            print("Rappel ajouté.")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/assistant/crypto_utils.py
+++ b/src/assistant/crypto_utils.py
@@ -1,0 +1,26 @@
+from Crypto.Cipher import AES
+from Crypto.Random import get_random_bytes
+import base64
+
+KEY_SIZE = 32  # AES-256
+
+
+def generate_key() -> bytes:
+    """Generate a random AES-256 key."""
+    return get_random_bytes(KEY_SIZE)
+
+
+def encrypt(key: bytes, data: str) -> str:
+    cipher = AES.new(key, AES.MODE_EAX)
+    ciphertext, tag = cipher.encrypt_and_digest(data.encode('utf-8'))
+    return base64.b64encode(cipher.nonce + tag + ciphertext).decode('utf-8')
+
+
+def decrypt(key: bytes, data: str) -> str:
+    raw = base64.b64decode(data.encode('utf-8'))
+    nonce = raw[:16]
+    tag = raw[16:32]
+    ciphertext = raw[32:]
+    cipher = AES.new(key, AES.MODE_EAX, nonce=nonce)
+    plaintext = cipher.decrypt_and_verify(ciphertext, tag)
+    return plaintext.decode('utf-8')

--- a/src/assistant/database.py
+++ b/src/assistant/database.py
@@ -1,0 +1,43 @@
+import sqlite3
+import datetime
+from pathlib import Path
+from .crypto_utils import encrypt, decrypt
+
+class Database:
+    def __init__(self, path: str, key: bytes):
+        self.key = key
+        self.path = Path(path)
+        self.conn = sqlite3.connect(self.path)
+        self._create_tables()
+
+    def _create_tables(self):
+        cursor = self.conn.cursor()
+        cursor.execute(
+            """CREATE TABLE IF NOT EXISTS events (
+                   id INTEGER PRIMARY KEY AUTOINCREMENT,
+                   title TEXT,
+                   time TEXT
+               )"""
+        )
+        self.conn.commit()
+
+    def add_event(self, title: str, dt: datetime.datetime):
+        enc_title = encrypt(self.key, title)
+        enc_time = encrypt(self.key, dt.isoformat())
+        cursor = self.conn.cursor()
+        cursor.execute(
+            "INSERT INTO events (title, time) VALUES (?, ?)",
+            (enc_title, enc_time),
+        )
+        self.conn.commit()
+
+    def get_events_for_day(self, date: datetime.date):
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT title, time FROM events")
+        results = []
+        for enc_title, enc_time in cursor.fetchall():
+            title = decrypt(self.key, enc_title)
+            dt = datetime.datetime.fromisoformat(decrypt(self.key, enc_time))
+            if dt.date() == date:
+                results.append({"title": title, "datetime": dt})
+        return results

--- a/src/assistant/nlp.py
+++ b/src/assistant/nlp.py
@@ -1,0 +1,27 @@
+import re
+import datetime
+from typing import Tuple, Optional, Dict
+
+Command = Tuple[str, Dict]
+
+
+def parse_command(text: str) -> Optional[Command]:
+    text_lower = text.lower()
+
+    if "demain" in text_lower and (
+        "qu'est-ce que j'ai" in text_lower or "que j'ai" in text_lower
+    ):
+        return "view_events_tomorrow", {}
+
+    m = re.search(r"rendez[- ]?vous.*?(\d{1,2})h", text_lower)
+    if m and "demain" in text_lower:
+        hour = int(m.group(1))
+        return "add_event_tomorrow", {"hour": hour}
+
+    m = re.search(r"rappelle[- ]?moi de (.+)\s+a\s+(\d{1,2})h", text_lower)
+    if m:
+        note = m.group(1)
+        hour = int(m.group(2))
+        return "add_reminder_today", {"note": note, "hour": hour}
+
+    return None

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,0 +1,42 @@
+'use client'
+
+import React, { useState, FormEvent } from 'react';
+
+interface Message {
+  sender: 'user' | 'assistant';
+  text: string;
+}
+
+const Chat: React.FC = () => {
+  const [messages, setMessages] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    const content = input.trim();
+    if (!content) return;
+    setMessages([...messages, { sender: 'user', text: content }]);
+    setInput('');
+  };
+
+  return (
+    <div>
+      <div className="chat-area">
+        {messages.map((msg, idx) => (
+          <div key={idx} className={`message ${msg.sender}`}>{msg.text}</div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className="chat-form">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Votre message..."
+        />
+        <button type="submit">Envoyer</button>
+      </form>
+    </div>
+  );
+};
+
+export default Chat;

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -11,12 +11,28 @@ const Chat: React.FC = () => {
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
 
-  const handleSubmit = (e: FormEvent) => {
+  const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
     const content = input.trim();
     if (!content) return;
-    setMessages([...messages, { sender: 'user', text: content }]);
+    setMessages((prev) => [...prev, { sender: 'user', text: content }]);
     setInput('');
+
+    try {
+      const res = await fetch('/api/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: content }),
+      });
+      const data = await res.json();
+      const reply = res.ok && data.reply ? data.reply : 'Erreur du serveur.';
+      setMessages((prev) => [...prev, { sender: 'assistant', text: reply }]);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        { sender: 'assistant', text: 'Erreur de réseau.' },
+      ]);
+    }
   };
 
   return (

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -1,0 +1,46 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+
+export default async function handler(
+  req: NextApiRequest,
+  res: NextApiResponse
+) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const { message } = req.body;
+  if (!message || typeof message !== 'string') {
+    return res.status(400).json({ error: 'Message is required' });
+  }
+
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    return res.status(500).json({ error: 'Missing OpenAI API key' });
+  }
+
+  try {
+    const response = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-3.5-turbo',
+        messages: [{ role: 'user', content: message }],
+      }),
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return res.status(500).json({ error: 'OpenAI error', detail: errorText });
+    }
+
+    const data = await response.json();
+    const reply = data.choices?.[0]?.message?.content ?? '';
+    return res.status(200).json({ reply });
+  } catch (err) {
+    return res.status(500).json({ error: 'Request failed' });
+  }
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -11,3 +11,32 @@ code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New',
     monospace;
 }
+
+.chat-area {
+  border: 1px solid #ccc;
+  padding: 1rem;
+  height: 300px;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+}
+
+.message {
+  margin-bottom: 0.5rem;
+}
+
+.message.user {
+  text-align: right;
+}
+
+.message.assistant {
+  text-align: left;
+}
+
+.chat-form {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.chat-form input {
+  flex: 1;
+}

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,0 +1,21 @@
+import sys
+import os
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+import datetime
+from assistant.database import Database
+from assistant.crypto_utils import generate_key
+
+
+def test_add_and_get_event(tmp_path):
+    key = generate_key()
+    db_file = tmp_path / "events.db"
+    db = Database(db_file, key)
+    dt = datetime.datetime(2024, 1, 1, 14, 0)
+    db.add_event("Test", dt)
+
+    events = db.get_events_for_day(dt.date())
+    assert len(events) == 1
+    assert events[0]["title"] == "Test"
+    assert events[0]["datetime"] == dt
+


### PR DESCRIPTION
## Summary
- set up Python requirements
- implement encrypted database utilities
- create simple NLP command parser and CLI assistant
- add unit tests for the database

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688777d52ec88321b3c5edae4a0ecc21