### PR TITLE
Implement persistent password-based encryption

### DIFF
--- a/src/assistant/assistant.py
+++ b/src/assistant/assistant.py
@@ -1,17 +1,50 @@
 import os
+import json
+import hashlib
+import base64
+import getpass
 import datetime
 from pathlib import Path
-from .crypto_utils import generate_key
+from .crypto_utils import derive_key, generate_salt
 from .database import Database
 from .nlp import parse_command
 
 DATA_DIR = Path(os.environ.get("PRIVUS_DATA", "data"))
 DB_PATH = DATA_DIR / "assistant.db"
+KEY_FILE = DATA_DIR / "key.json"
+
+
+def _load_or_create_key() -> bytes:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    if KEY_FILE.exists():
+        with KEY_FILE.open("r") as f:
+            info = json.load(f)
+        salt = base64.b64decode(info["salt"])
+        stored_hash = info["hash"]
+        password = getpass.getpass("Mot de passe: ")
+        key = derive_key(password, salt)
+        if hashlib.sha256(key).hexdigest() != stored_hash:
+            raise ValueError("Mot de passe incorrect")
+        return key
+    else:
+        password = getpass.getpass("Cr\xe9ez un mot de passe: ")
+        salt = generate_salt()
+        key = derive_key(password, salt)
+        info = {
+            "salt": base64.b64encode(salt).decode("utf-8"),
+            "hash": hashlib.sha256(key).hexdigest(),
+        }
+        with KEY_FILE.open("w") as f:
+            json.dump(info, f)
+        return key
 
 
 def main():
-    DATA_DIR.mkdir(parents=True, exist_ok=True)
-    key = generate_key()
+    try:
+        key = _load_or_create_key()
+    except ValueError as e:
+        print(str(e))
+        return
     db = Database(DB_PATH, key)
 
     print("Assistant personnel Privus. Tapez 'exit' pour quitter.")

--- a/src/assistant/crypto_utils.py
+++ b/src/assistant/crypto_utils.py
@@ -1,6 +1,12 @@
 from Crypto.Cipher import AES
 from Crypto.Random import get_random_bytes
+from Crypto.Protocol.KDF import PBKDF2
+from Crypto.Hash import SHA256
 import base64
+import os
+
+SALT_SIZE = 16
+PBKDF2_ITERATIONS = 100_000
 
 KEY_SIZE = 32  # AES-256
 
@@ -8,6 +14,15 @@ KEY_SIZE = 32  # AES-256
 def generate_key() -> bytes:
     """Generate a random AES-256 key."""
     return get_random_bytes(KEY_SIZE)
+
+
+def derive_key(password: str, salt: bytes, iterations: int = PBKDF2_ITERATIONS) -> bytes:
+    """Derive a key from the given password and salt using PBKDF2."""
+    return PBKDF2(password.encode("utf-8"), salt, dkLen=KEY_SIZE, count=iterations, hmac_hash_module=SHA256)
+
+
+def generate_salt() -> bytes:
+    return os.urandom(SALT_SIZE)
 
 
 def encrypt(key: bytes, data: str) -> str:


### PR DESCRIPTION
## Summary
- derive encryption keys from a user-supplied password with PBKDF2
- store salt and hash of the derived key in a `key.json` file
- prompt for password on startup and verify it before opening the database

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `PYTHONPATH=src python - <<'PY'
import json, base64, hashlib, datetime, pathlib
from assistant.crypto_utils import derive_key, generate_salt
from assistant.database import Database
p=pathlib.Path('data_test');p.mkdir(exist_ok=True)
keyfile=p/'key.json'
password='secret'
salt=generate_salt()
key=derive_key(password,salt)
keyfile.write_text(json.dumps({'salt': base64.b64encode(salt).decode(),'hash': hashlib.sha256(key).hexdigest()}))
db=Database(p/'assistant.db',key);db.add_event('Test',datetime.datetime(2024,1,1,15,0));db.conn.close()
info=json.loads(keyfile.read_text());key2=derive_key(password,base64.b64decode(info['salt']))
print('events:', Database(p/'assistant.db',key2).get_events_for_day(datetime.date(2024,1,1)))
PY

------
https://chatgpt.com/codex/tasks/task_e_6887b1199c5883218dabe6b237b5388d