### PR TITLE
Add agenda features in chat API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+node_modules/
+.env

--- a/src/app/agenda/page.tsx
+++ b/src/app/agenda/page.tsx
@@ -1,0 +1,74 @@
+'use client'
+
+import React, { useState, useEffect, FormEvent } from 'react';
+
+interface EventItem {
+  id: number;
+  title: string;
+  datetime: string;
+}
+
+const AgendaPage: React.FC = () => {
+  const [events, setEvents] = useState<EventItem[]>([]);
+  const [title, setTitle] = useState('');
+  const [time, setTime] = useState('');
+
+  const fetchEvents = async () => {
+    const res = await fetch('/api/events');
+    if (res.ok) {
+      const data = await res.json();
+      setEvents(data.events || []);
+    }
+  };
+
+  useEffect(() => {
+    fetchEvents();
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    if (!title.trim() || !time) return;
+    const res = await fetch('/api/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title, time }),
+    });
+    if (res.ok) {
+      setTitle('');
+      setTime('');
+      fetchEvents();
+    }
+  };
+
+  return (
+    <div>
+      <h1>Agenda</h1>
+      <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
+        <input
+          type="text"
+          value={title}
+          onChange={(e) => setTitle(e.target.value)}
+          placeholder="Titre"
+        />
+        <input
+          type="time"
+          value={time}
+          onChange={(e) => setTime(e.target.value)}
+        />
+        <button type="submit">Ajouter</button>
+      </form>
+      <ul>
+        {events.map((ev) => (
+          <li key={ev.id}>
+            {new Date(ev.datetime).toLocaleTimeString('fr-FR', {
+              hour: '2-digit',
+              minute: '2-digit',
+            })}{' '}– {ev.title}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default AgendaPage;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,10 +1,22 @@
-import React from 'react';
+'use client'
+
+import React, { useEffect, useState } from 'react';
 import Chat from '@/components/Chat';
 
 const HomePage: React.FC = () => {
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    fetch('/api/profile')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data && typeof data.name === 'string') setName(data.name);
+      });
+  }, []);
+
   return (
     <div>
-      <h1>Bienvenue sur Privus</h1>
+      <h1>{name ? `Bonjour ${name} !` : 'Bienvenue sur Privus'}</h1>
       <Chat />
     </div>
   );

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,69 @@
+'use client'
+
+import React, { useEffect, useState, FormEvent } from 'react';
+
+const SettingsPage: React.FC = () => {
+  const [name, setName] = useState('');
+  const [model, setModel] = useState('gpt-3.5-turbo');
+  const [tone, setTone] = useState('vous');
+  const [status, setStatus] = useState('');
+
+  useEffect(() => {
+    fetch('/api/profile')
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (!data) return;
+        if (typeof data.name === 'string') setName(data.name);
+        if (typeof data.model === 'string') setModel(data.model);
+        if (typeof data.tone === 'string') setTone(data.tone);
+      });
+  }, []);
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    const res = await fetch('/api/profile', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name, model, tone }),
+    });
+    if (res.ok) {
+      setStatus('Enregistré');
+    } else {
+      setStatus("Erreur lors de l'enregistrement");
+    }
+  };
+
+  return (
+    <div>
+      <h1>Paramètres</h1>
+      <form
+        onSubmit={handleSubmit}
+        style={{ display: 'flex', flexDirection: 'column', gap: '0.5rem', maxWidth: '20rem' }}
+      >
+        <label>
+          Nom
+          <input type="text" value={name} onChange={(e) => setName(e.target.value)} />
+        </label>
+        <label>
+          Modèle IA
+          <select value={model} onChange={(e) => setModel(e.target.value)}>
+            <option value="gpt-3.5-turbo">GPT-3.5</option>
+            <option value="gpt-4">GPT-4</option>
+            <option value="local">Modèle local</option>
+          </select>
+        </label>
+        <label>
+          Ton
+          <select value={tone} onChange={(e) => setTone(e.target.value)}>
+            <option value="vous">Vouvoyer</option>
+            <option value="tu">Tutoyer</option>
+          </select>
+        </label>
+        <button type="submit">Sauvegarder</button>
+      </form>
+      {status && <p>{status}</p>}
+    </div>
+  );
+};
+
+export default SettingsPage;

--- a/src/assistant/database.py
+++ b/src/assistant/database.py
@@ -41,3 +41,14 @@ class Database:
             if dt.date() == date:
                 results.append({"title": title, "datetime": dt})
         return results
+
+    def get_all_events(self):
+        cursor = self.conn.cursor()
+        cursor.execute("SELECT id, title, time FROM events")
+        events = []
+        for event_id, enc_title, enc_time in cursor.fetchall():
+            title = decrypt(self.key, enc_title)
+            dt = datetime.datetime.fromisoformat(decrypt(self.key, enc_time))
+            events.append({"id": event_id, "title": title, "datetime": dt})
+        events.sort(key=lambda e: e["datetime"])
+        return events

--- a/src/assistant/profile.py
+++ b/src/assistant/profile.py
@@ -1,0 +1,55 @@
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict
+
+DATA_DIR = Path(os.environ.get("PRIVUS_DATA", "data"))
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+PROFILE_FILE = DATA_DIR / "profile.json"
+
+DEFAULT_PROFILE = {
+    "name": "",
+    "model": "gpt-3.5-turbo",
+    "tone": "vous",
+    "language": "fr",
+}
+
+
+def load_profile() -> Dict[str, Any]:
+    if PROFILE_FILE.exists():
+        try:
+            with PROFILE_FILE.open("r", encoding="utf-8") as f:
+                data = json.load(f)
+            if isinstance(data, dict):
+                return {**DEFAULT_PROFILE, **data}
+        except Exception:
+            pass
+    return DEFAULT_PROFILE.copy()
+
+
+def save_profile(data: Dict[str, Any]) -> None:
+    PROFILE_FILE.write_text(
+        json.dumps({**DEFAULT_PROFILE, **data}, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+if __name__ == "__main__":
+    import sys
+
+    if len(sys.argv) < 2:
+        print("Missing command", file=sys.stderr)
+        sys.exit(1)
+    cmd = sys.argv[1]
+    if cmd == "get":
+        print(json.dumps(load_profile(), ensure_ascii=False))
+    elif cmd == "set" and len(sys.argv) >= 3:
+        try:
+            payload = json.loads(sys.argv[2])
+        except Exception as e:
+            print("Invalid JSON", file=sys.stderr)
+            sys.exit(1)
+        save_profile(payload)
+        print("OK")
+    else:
+        print("Invalid command", file=sys.stderr)
+        sys.exit(1)

--- a/src/assistant/web_bridge.py
+++ b/src/assistant/web_bridge.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from .database import Database
 from .crypto_utils import generate_key
+from .profile import load_profile, save_profile
 
 DATA_DIR = Path(os.environ.get("PRIVUS_DATA", "data"))
 DATA_DIR.mkdir(parents=True, exist_ok=True)
@@ -41,6 +42,21 @@ def cmd_list() -> None:
     print(json.dumps(events, default=str))
 
 
+def cmd_profile_get() -> None:
+    profile = load_profile()
+    print(json.dumps(profile, ensure_ascii=False))
+
+
+def cmd_profile_set(json_str: str) -> None:
+    try:
+        data = json.loads(json_str)
+    except Exception:
+        print("Invalid JSON", file=sys.stderr)
+        sys.exit(1)
+    save_profile(data)
+    print("OK")
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Missing command", file=sys.stderr)
@@ -52,6 +68,10 @@ if __name__ == "__main__":
         cmd_add(sys.argv[2], sys.argv[3])
     elif command == "list":
         cmd_list()
+    elif command == "profile_get":
+        cmd_profile_get()
+    elif command == "profile_set" and len(sys.argv) >= 3:
+        cmd_profile_set(sys.argv[2])
     else:
         print("Invalid command", file=sys.stderr)
         sys.exit(1)

--- a/src/assistant/web_bridge.py
+++ b/src/assistant/web_bridge.py
@@ -1,0 +1,51 @@
+import sys
+import json
+import os
+import datetime
+from pathlib import Path
+
+from .database import Database
+from .crypto_utils import generate_key
+
+DATA_DIR = Path(os.environ.get("PRIVUS_DATA", "data"))
+DATA_DIR.mkdir(parents=True, exist_ok=True)
+DB_PATH = DATA_DIR / "assistant_web.db"
+KEY_PATH = DATA_DIR / "web_key"
+
+
+def _load_key() -> bytes:
+    if KEY_PATH.exists():
+        return KEY_PATH.read_bytes()
+    key = generate_key()
+    KEY_PATH.write_bytes(key)
+    return key
+
+
+_db = Database(DB_PATH, _load_key())
+
+
+def cmd_get(date_str: str) -> None:
+    date = datetime.datetime.strptime(date_str, "%Y-%m-%d").date()
+    events = _db.get_events_for_day(date)
+    print(json.dumps(events, default=str))
+
+
+def cmd_add(title: str, dt_str: str) -> None:
+    dt = datetime.datetime.fromisoformat(dt_str)
+    _db.add_event(title, dt)
+    print("OK")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Missing command", file=sys.stderr)
+        sys.exit(1)
+    command = sys.argv[1]
+    if command == "get" and len(sys.argv) >= 3:
+        cmd_get(sys.argv[2])
+    elif command == "add" and len(sys.argv) >= 4:
+        cmd_add(sys.argv[2], sys.argv[3])
+    else:
+        print("Invalid command", file=sys.stderr)
+        sys.exit(1)
+

--- a/src/assistant/web_bridge.py
+++ b/src/assistant/web_bridge.py
@@ -36,6 +36,11 @@ def cmd_add(title: str, dt_str: str) -> None:
     print("OK")
 
 
+def cmd_list() -> None:
+    events = _db.get_all_events()
+    print(json.dumps(events, default=str))
+
+
 if __name__ == "__main__":
     if len(sys.argv) < 2:
         print("Missing command", file=sys.stderr)
@@ -45,6 +50,8 @@ if __name__ == "__main__":
         cmd_get(sys.argv[2])
     elif command == "add" and len(sys.argv) >= 4:
         cmd_add(sys.argv[2], sys.argv[3])
+    elif command == "list":
+        cmd_list()
     else:
         print("Invalid command", file=sys.stderr)
         sys.exit(1)

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -112,7 +112,7 @@ const Chat: React.FC = () => {
   return (
     <div className="chat-wrapper">
       <div style={{ marginBottom: '0.5rem' }}>
-        <a href="/agenda">Voir l'agenda</a>
+        <a href="/agenda">Voir l'agenda</a> | <a href="/settings">Paramètres</a>
       </div>
       <div className="chat-area">
         {messages.map((msg, idx) => (

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -60,6 +60,9 @@ const Chat: React.FC = () => {
 
   return (
     <div className="chat-wrapper">
+      <div style={{ marginBottom: '0.5rem' }}>
+        <a href="/agenda">Voir l'agenda</a>
+      </div>
       <div className="chat-area">
         {messages.map((msg, idx) => (
           <div key={idx} className={`message ${msg.role}`}><div className="bubble">{msg.content}</div></div>

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -1,6 +1,12 @@
 'use client'
 
-import React, { useState, FormEvent, KeyboardEvent, useRef, useEffect } from 'react';
+import React, {
+  useState,
+  FormEvent,
+  KeyboardEvent,
+  useRef,
+  useEffect,
+} from 'react';
 
 interface Message {
   role: 'user' | 'assistant';
@@ -12,18 +18,45 @@ const Chat: React.FC = () => {
   const [input, setInput] = useState('');
   const [loading, setLoading] = useState(false);
   const endRef = useRef<HTMLDivElement | null>(null);
+  const [recognizing, setRecognizing] = useState(false);
+  const recognitionRef = useRef<any>(null);
 
   useEffect(() => {
     endRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, loading]);
 
-  const sendMessage = async () => {
-    const content = input.trim();
+  useEffect(() => {
+    const SpeechRec =
+      typeof window !== 'undefined'
+        ? (window as any).SpeechRecognition ||
+          (window as any).webkitSpeechRecognition
+        : null;
+    if (!SpeechRec) return;
+    const recog = new SpeechRec();
+    recog.lang = 'fr-FR';
+    recog.onresult = (e: any) => {
+      const transcript = e.results[0][0].transcript;
+      setRecognizing(false);
+      sendMessage(transcript);
+    };
+    recog.onerror = () => {
+      setRecognizing(false);
+      alert('La reconnaissance vocale a échoué');
+    };
+    recog.onend = () => setRecognizing(false);
+    recognitionRef.current = recog;
+  }, []);
+
+  const sendMessage = async (override?: string) => {
+    const content = (override ?? input).trim();
     if (!content) return;
     const newMessages = [...messages, { role: 'user', content }];
     setMessages(newMessages);
     setInput('');
     setLoading(true);
+    if (typeof window !== 'undefined' && window.speechSynthesis) {
+      window.speechSynthesis.cancel();
+    }
 
     try {
       const res = await fetch('/api/chat', {
@@ -36,11 +69,19 @@ const Chat: React.FC = () => {
       const data = await res.json();
       const reply = res.ok && data.reply ? data.reply : 'Erreur du serveur.';
       setMessages((prev) => [...prev, { role: 'assistant', content: reply }]);
+      if (typeof window !== 'undefined' && window.speechSynthesis) {
+        const u = new SpeechSynthesisUtterance(reply);
+        u.lang = 'fr-FR';
+        window.speechSynthesis.speak(u);
+      }
     } catch {
-      setMessages((prev) => [
-        ...prev,
-        { role: 'assistant', content: 'Erreur de réseau.' },
-      ]);
+      const errMsg = 'Erreur de réseau.';
+      setMessages((prev) => [...prev, { role: 'assistant', content: errMsg }]);
+      if (typeof window !== 'undefined' && window.speechSynthesis) {
+        const u = new SpeechSynthesisUtterance(errMsg);
+        u.lang = 'fr-FR';
+        window.speechSynthesis.speak(u);
+      }
     } finally {
       setLoading(false);
     }
@@ -56,6 +97,16 @@ const Chat: React.FC = () => {
       e.preventDefault();
       sendMessage();
     }
+  };
+
+  const startRecognition = () => {
+    const rec = recognitionRef.current;
+    if (!rec) {
+      alert("La reconnaissance vocale n'est pas supportée par votre navigateur");
+      return;
+    }
+    setRecognizing(true);
+    rec.start();
   };
 
   return (
@@ -81,6 +132,14 @@ const Chat: React.FC = () => {
           placeholder="Votre message..."
           disabled={loading}
         />
+        <button
+          type="button"
+          onClick={startRecognition}
+          disabled={loading}
+          style={{ marginLeft: '0.5rem' }}
+        >
+          {recognizing ? '🎤 Enregistrement…' : '🎤'}
+        </button>
         <button type="submit" disabled={loading || !input.trim()}>Envoyer</button>
       </form>
     </div>

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -15,6 +15,20 @@ export default async function handler(
     return res.status(400).json({ error: 'Messages are required' });
   }
 
+  const profPy = spawnSync('python3', ['src/assistant/web_bridge.py', 'profile_get'], {
+    encoding: 'utf-8',
+  });
+  let profile: any = {};
+  if (!profPy.error) {
+    try {
+      profile = JSON.parse(profPy.stdout.trim() || '{}');
+    } catch {
+      profile = {};
+    }
+  }
+  const model = typeof profile.model === 'string' ? profile.model : 'gpt-3.5-turbo';
+  const tone = profile.tone === 'tu' ? 'tu' : 'vous';
+
   const last = messages[messages.length - 1];
   const lastContent =
     typeof last?.content === 'string' ? last.content.toLowerCase() : '';
@@ -74,6 +88,10 @@ export default async function handler(
     return res.status(500).json({ error: 'Missing OpenAI API key' });
   }
 
+  const requestMessages = tone === 'tu'
+    ? [{ role: 'system', content: "Tutoye l'utilisateur dans tes réponses." }, ...messages]
+    : messages;
+
   try {
     const response = await fetch('https://api.openai.com/v1/chat/completions', {
       method: 'POST',
@@ -82,8 +100,8 @@ export default async function handler(
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: 'gpt-3.5-turbo',
-        messages,
+        model,
+        messages: requestMessages,
       }),
     });
 

--- a/src/pages/api/chat.ts
+++ b/src/pages/api/chat.ts
@@ -1,4 +1,5 @@
 import type { NextApiRequest, NextApiResponse } from 'next';
+import { spawnSync } from 'child_process';
 
 export default async function handler(
   req: NextApiRequest,
@@ -12,6 +13,60 @@ export default async function handler(
   const { messages } = req.body;
   if (!Array.isArray(messages)) {
     return res.status(400).json({ error: 'Messages are required' });
+  }
+
+  const last = messages[messages.length - 1];
+  const lastContent =
+    typeof last?.content === 'string' ? last.content.toLowerCase() : '';
+
+  if (lastContent.includes('demain') && lastContent.includes("que j'ai")) {
+    const tomorrow = new Date();
+    tomorrow.setDate(tomorrow.getDate() + 1);
+    const dateStr = tomorrow.toISOString().slice(0, 10);
+    const py = spawnSync('python3', ['src/assistant/web_bridge.py', 'get', dateStr], {
+      encoding: 'utf-8',
+    });
+    if (py.error) {
+      return res.status(500).json({ error: 'Failed to access agenda' });
+    }
+    try {
+      const events = JSON.parse(py.stdout.trim() || '[]');
+      if (!events.length) {
+        return res
+          .status(200)
+          .json({ reply: "Vous n'avez aucun événement prévu pour demain." });
+      }
+      const lines = events.map(
+        (ev: { title: string; datetime: string }) =>
+          `- ${ev.title} à ${new Date(ev.datetime).toLocaleTimeString('fr-FR', {
+            hour: '2-digit',
+            minute: '2-digit',
+          })}`
+      );
+      const reply = `Demain, vous avez :\n${lines.join('\n')}`;
+      return res.status(200).json({ reply });
+    } catch {
+      return res.status(500).json({ error: 'Invalid agenda data' });
+    }
+  }
+
+  const reminderMatch = lastContent.match(
+    /rappelle[- ]?moi de (.+?)\s+a\s+(\d{1,2})h/
+  );
+  if (reminderMatch) {
+    const note = reminderMatch[1];
+    const hour = parseInt(reminderMatch[2], 10);
+    const now = new Date();
+    now.setHours(hour, 0, 0, 0);
+    spawnSync('python3', [
+      'src/assistant/web_bridge.py',
+      'add',
+      `Rappel: ${note}`,
+      now.toISOString(),
+    ]);
+    return res.status(200).json({
+      reply: `D'accord, je vous rappellerai de ${note} à ${hour}h aujourd'hui.`,
+    });
   }
 
   const apiKey = process.env.OPENAI_API_KEY;

--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -1,0 +1,45 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { spawnSync } from 'child_process';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const py = spawnSync('python3', ['src/assistant/web_bridge.py', 'list'], {
+      encoding: 'utf-8',
+    });
+    if (py.error) {
+      return res.status(500).json({ error: 'Failed to access agenda' });
+    }
+    try {
+      const events = JSON.parse(py.stdout.trim() || '[]');
+      return res.status(200).json({ events });
+    } catch {
+      return res.status(500).json({ error: 'Invalid agenda data' });
+    }
+  }
+
+  if (req.method === 'POST') {
+    const { title, time } = req.body || {};
+    if (!title || !time) {
+      return res.status(400).json({ error: 'Title and time required' });
+    }
+    const now = new Date();
+    const [h, m] = String(time).split(':').map((s: string) => parseInt(s, 10));
+    if (Number.isNaN(h) || Number.isNaN(m)) {
+      return res.status(400).json({ error: 'Invalid time format' });
+    }
+    const dt = new Date(now);
+    dt.setHours(h, m, 0, 0);
+    const py = spawnSync(
+      'python3',
+      ['src/assistant/web_bridge.py', 'add', title, dt.toISOString()],
+      { encoding: 'utf-8' }
+    );
+    if (py.error) {
+      return res.status(500).json({ error: 'Failed to add event' });
+    }
+    return res.status(200).json({ status: 'ok' });
+  }
+
+  res.setHeader('Allow', 'GET, POST');
+  return res.status(405).end();
+}

--- a/src/pages/api/profile.ts
+++ b/src/pages/api/profile.ts
@@ -1,0 +1,38 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import { spawnSync } from 'child_process';
+
+export default function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === 'GET') {
+    const py = spawnSync('python3', ['src/assistant/web_bridge.py', 'profile_get'], {
+      encoding: 'utf-8',
+    });
+    if (py.error) {
+      return res.status(500).json({ error: 'Failed to load profile' });
+    }
+    try {
+      const profile = JSON.parse(py.stdout.trim() || '{}');
+      return res.status(200).json(profile);
+    } catch {
+      return res.status(500).json({ error: 'Invalid profile data' });
+    }
+  }
+
+  if (req.method === 'POST') {
+    const payload = JSON.stringify(req.body || {});
+    const py = spawnSync(
+      'python3',
+      ['src/assistant/web_bridge.py', 'profile_set', payload],
+      { encoding: 'utf-8' }
+    );
+    if (py.error) {
+      return res.status(500).json({ error: 'Failed to save profile' });
+    }
+    if (py.status !== 0) {
+      return res.status(500).json({ error: 'Profile save error' });
+    }
+    return res.status(200).json({ status: 'ok' });
+  }
+
+  res.setHeader('Allow', 'GET, POST');
+  return res.status(405).end();
+}

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -19,3 +19,18 @@ def test_add_and_get_event(tmp_path):
     assert events[0]["title"] == "Test"
     assert events[0]["datetime"] == dt
 
+
+def test_get_all_events(tmp_path):
+    key = generate_key()
+    db_file = tmp_path / "events.db"
+    db = Database(db_file, key)
+    dt1 = datetime.datetime(2024, 1, 1, 10, 0)
+    dt2 = datetime.datetime(2024, 1, 1, 12, 0)
+    db.add_event("A", dt1)
+    db.add_event("B", dt2)
+
+    events = db.get_all_events()
+    assert len(events) == 2
+    assert events[0]["title"] == "A"
+    assert events[1]["title"] == "B"
+

--- a/tests/test_profile.py
+++ b/tests/test_profile.py
@@ -1,0 +1,26 @@
+import importlib
+
+
+def load_module(tmp_path, monkeypatch):
+    monkeypatch.setenv('PRIVUS_DATA', str(tmp_path))
+    import assistant.profile as profile
+    importlib.reload(profile)
+    return profile
+
+
+def test_load_default(tmp_path, monkeypatch):
+    profile_module = load_module(tmp_path, monkeypatch)
+    profile = profile_module.load_profile()
+    assert profile['name'] == ''
+    assert profile['model'] == 'gpt-3.5-turbo'
+    assert profile['tone'] == 'vous'
+    assert profile['language'] == 'fr'
+
+
+def test_save_and_load(tmp_path, monkeypatch):
+    profile_module = load_module(tmp_path, monkeypatch)
+    profile_module.save_profile({'name': 'Alice', 'model': 'gpt-4', 'tone': 'tu'})
+    profile = profile_module.load_profile()
+    assert profile['name'] == 'Alice'
+    assert profile['model'] == 'gpt-4'
+    assert profile['tone'] == 'tu'


### PR DESCRIPTION
## Summary
- integrate SQLite-backed agenda actions in `src/pages/api/chat.ts`
- implement Python bridge `src/assistant/web_bridge.py` for event retrieval and creation
- add `.gitignore`

## Testing
- `pip install pycryptodome`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888a97af7648321a35596cf2d48badb