### PR TITLE
Enhance agenda features

### DIFF
--- a/src/app/agenda/page.tsx
+++ b/src/app/agenda/page.tsx
@@ -12,6 +12,10 @@ const AgendaPage: React.FC = () => {
   const [events, setEvents] = useState<EventItem[]>([]);
   const [title, setTitle] = useState('');
   const [time, setTime] = useState('');
+  const [date, setDate] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [deleteId, setDeleteId] = useState<number | null>(null);
+  const [message, setMessage] = useState('');
 
   const fetchEvents = async () => {
     const res = await fetch('/api/events');
@@ -22,22 +26,42 @@ const AgendaPage: React.FC = () => {
   };
 
   useEffect(() => {
+    const today = new Date().toISOString().slice(0, 10);
+    setDate(today);
     fetchEvents();
   }, []);
 
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
-    if (!title.trim() || !time) return;
+    if (!title.trim() || !time || !date) return;
+    setLoading(true);
     const res = await fetch('/api/events', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ title, time }),
+      body: JSON.stringify({ title, time, date }),
     });
     if (res.ok) {
       setTitle('');
       setTime('');
+      setMessage("\u00c9v\u00e9nement ajout\u00e9");
       fetchEvents();
+    } else {
+      setMessage("Erreur lors de l'ajout");
     }
+    setLoading(false);
+  };
+
+  const handleDelete = async (id: number) => {
+    if (!confirm('Supprimer cet \u00e9v\u00e9nement ?')) return;
+    setDeleteId(id);
+    const res = await fetch('/api/events?id=' + id, { method: 'DELETE' });
+    if (res.ok) {
+      setMessage("\u00c9v\u00e9nement supprim\u00e9");
+      fetchEvents();
+    } else {
+      setMessage('Erreur de suppression');
+    }
+    setDeleteId(null);
   };
 
   return (
@@ -51,19 +75,34 @@ const AgendaPage: React.FC = () => {
           placeholder="Titre"
         />
         <input
+          type="date"
+          value={date}
+          onChange={(e) => setDate(e.target.value)}
+        />
+        <input
           type="time"
           value={time}
           onChange={(e) => setTime(e.target.value)}
         />
-        <button type="submit">Ajouter</button>
+        <button type="submit" disabled={loading}>Ajouter</button>
       </form>
+      {message && <p>{message}</p>}
       <ul>
         {events.map((ev) => (
           <li key={ev.id}>
+            {new Date(ev.datetime).toLocaleDateString('fr-FR')} à{' '}
             {new Date(ev.datetime).toLocaleTimeString('fr-FR', {
               hour: '2-digit',
               minute: '2-digit',
-            })}{' '}– {ev.title}
+            })}
+            {' '}– {ev.title}{' '}
+            <button
+              onClick={() => handleDelete(ev.id)}
+              disabled={deleteId === ev.id}
+              style={{ marginLeft: '0.5rem' }}
+            >
+              {deleteId === ev.id ? '...' : 'Supprimer'}
+            </button>
           </li>
         ))}
       </ul>

--- a/src/assistant/database.py
+++ b/src/assistant/database.py
@@ -52,3 +52,10 @@ class Database:
             events.append({"id": event_id, "title": title, "datetime": dt})
         events.sort(key=lambda e: e["datetime"])
         return events
+
+    def delete_event(self, event_id: int) -> bool:
+        cursor = self.conn.cursor()
+        cursor.execute("DELETE FROM events WHERE id = ?", (event_id,))
+        deleted = cursor.rowcount
+        self.conn.commit()
+        return deleted > 0

--- a/src/assistant/web_bridge.py
+++ b/src/assistant/web_bridge.py
@@ -42,6 +42,19 @@ def cmd_list() -> None:
     print(json.dumps(events, default=str))
 
 
+def cmd_delete(id_str: str) -> None:
+    try:
+        event_id = int(id_str)
+    except ValueError:
+        print("Invalid ID", file=sys.stderr)
+        sys.exit(1)
+    if _db.delete_event(event_id):
+        print("OK")
+    else:
+        print("Not found", file=sys.stderr)
+        sys.exit(1)
+
+
 def cmd_profile_get() -> None:
     profile = load_profile()
     print(json.dumps(profile, ensure_ascii=False))
@@ -68,6 +81,8 @@ if __name__ == "__main__":
         cmd_add(sys.argv[2], sys.argv[3])
     elif command == "list":
         cmd_list()
+    elif command == "delete" and len(sys.argv) >= 3:
+        cmd_delete(sys.argv[2])
     elif command == "profile_get":
         cmd_profile_get()
     elif command == "profile_set" and len(sys.argv) >= 3:
@@ -75,4 +90,3 @@ if __name__ == "__main__":
     else:
         print("Invalid command", file=sys.stderr)
         sys.exit(1)
-

--- a/src/pages/api/events.ts
+++ b/src/pages/api/events.ts
@@ -18,17 +18,14 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
   }
 
   if (req.method === 'POST') {
-    const { title, time } = req.body || {};
-    if (!title || !time) {
-      return res.status(400).json({ error: 'Title and time required' });
+    const { title, time, date } = req.body || {};
+    if (!title || !time || !date) {
+      return res.status(400).json({ error: 'Title, date and time required' });
     }
-    const now = new Date();
-    const [h, m] = String(time).split(':').map((s: string) => parseInt(s, 10));
-    if (Number.isNaN(h) || Number.isNaN(m)) {
-      return res.status(400).json({ error: 'Invalid time format' });
+    const dt = new Date(`${date}T${time}:00`);
+    if (isNaN(dt.getTime())) {
+      return res.status(400).json({ error: 'Invalid date or time format' });
     }
-    const dt = new Date(now);
-    dt.setHours(h, m, 0, 0);
     const py = spawnSync(
       'python3',
       ['src/assistant/web_bridge.py', 'add', title, dt.toISOString()],
@@ -40,6 +37,22 @@ export default function handler(req: NextApiRequest, res: NextApiResponse) {
     return res.status(200).json({ status: 'ok' });
   }
 
-  res.setHeader('Allow', 'GET, POST');
+  if (req.method === 'DELETE') {
+    const { id } = req.query;
+    const idNum = parseInt(Array.isArray(id) ? id[0] : id || '', 10);
+    if (!id || Number.isNaN(idNum)) {
+      return res.status(400).json({ error: 'ID required' });
+    }
+    const py = spawnSync('python3', ['src/assistant/web_bridge.py', 'delete', String(idNum)], { encoding: 'utf-8' });
+    if (py.error) {
+      return res.status(500).json({ error: 'Failed to delete event' });
+    }
+    if (py.status !== 0) {
+      return res.status(404).json({ error: 'Event not found' });
+    }
+    return res.status(200).json({ status: 'ok' });
+  }
+
+  res.setHeader('Allow', 'GET, POST, DELETE');
   return res.status(405).end();
 }

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -1,6 +1,9 @@
 import sys
 import os
-sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..', 'src')))
+
+sys.path.insert(
+    0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..", "src"))
+)
 
 import datetime
 from assistant.database import Database
@@ -34,3 +37,15 @@ def test_get_all_events(tmp_path):
     assert events[0]["title"] == "A"
     assert events[1]["title"] == "B"
 
+
+def test_delete_event(tmp_path):
+    key = generate_key()
+    db_file = tmp_path / "events.db"
+    db = Database(db_file, key)
+    dt = datetime.datetime(2024, 1, 1, 15, 0)
+    db.add_event("ToDelete", dt)
+    event_id = db.get_all_events()[0]["id"]
+    assert db.delete_event(event_id) is True
+    assert db.get_all_events() == []
+    # deleting again should return False
+    assert db.delete_event(event_id) is False


### PR DESCRIPTION
## Summary
- add event deletion in database and API
- allow specifying a date when creating events
- show date and delete button in the agenda UI
- test the new database deletion logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6888bf02364c83218eea96a8b6935c9d