### PR TITLE
Ajout du support PWA offline

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,35 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-};
+const withPWA = require('next-pwa')({
+  dest: 'public',
+  register: true,
+  skipWaiting: true,
+  dynamicStartUrl: true,
+  runtimeCaching: [
+    {
+      urlPattern: /^\/_next\//,
+      handler: 'CacheFirst',
+      options: {
+        cacheName: 'next-static',
+        expiration: { maxEntries: 64, maxAgeSeconds: 60 * 60 * 24 * 30 },
+      },
+    },
+    {
+      urlPattern: /^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/.*$/i,
+      handler: 'CacheFirst',
+      options: {
+        cacheName: 'google-fonts',
+        expiration: { maxEntries: 20, maxAgeSeconds: 60 * 60 * 24 * 365 },
+      },
+    },
+    {
+      urlPattern: /\/api\/events/,
+      handler: 'NetworkFirst',
+      options: {
+        cacheName: 'api-events',
+        expiration: { maxEntries: 50, maxAgeSeconds: 60 * 60 * 24 },
+      },
+    },
+  ],
+  fallbacks: { html: '/offline' },
+});
 
-module.exports = nextConfig;
+module.exports = withPWA({ reactStrictMode: true });

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,5 +21,13 @@
   "bugs": {
     "url": "https://github.com/Mantinum/privus/issues"
   },
-  "homepage": "https://github.com/Mantinum/privus#readme"
+  "homepage": "https://github.com/Mantinum/privus#readme",
+  "dependencies": {
+    "next-pwa": "^5.6.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "^1.39.0",
+    "@types/react": "19.1.9",
+    "typescript": "5.8.3"
+  }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,12 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+
+const config: PlaywrightTestConfig = {
+  webServer: {
+    command: 'npx next start -p 3000',
+    port: 3000,
+    timeout: 120000,
+    reuseExistingServer: true,
+  },
+};
+
+export default config;

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+// TODO: Remplacer ces data-URL par de vrais PNG dans un commit manuel ultérieur (pas dans cette PR).
+{
+  "name": "Privus – Assistant IA",
+  "short_name": "Privus",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#141414",
+  "background_color": "#141414",
+  "orientation": "portrait",
+  "icons": [
+    { "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottQAAAABJRU5ErkJggg==", "sizes": "192x192", "type": "image/png" },
+    { "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottQAAAABJRU5ErkJggg==", "sizes": "256x256", "type": "image/png" },
+    { "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottQAAAABJRU5ErkJggg==", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/src/app/agenda/page.tsx
+++ b/src/app/agenda/page.tsx
@@ -16,13 +16,21 @@ const AgendaPage: React.FC = () => {
   const [loading, setLoading] = useState(false);
   const [deleteId, setDeleteId] = useState<number | null>(null);
   const [message, setMessage] = useState('');
+  const [offline, setOffline] = useState(false);
 
   const fetchEvents = async () => {
-    const res = await fetch('/api/events');
-    if (res.ok) {
-      const data = await res.json();
-      setEvents(data.events || []);
+    let fromCache = !navigator.onLine;
+    try {
+      const res = await fetch('/api/events');
+      if (res.ok) {
+        const data = await res.json();
+        setEvents(data.events || []);
+        if (!navigator.onLine) fromCache = true;
+      }
+    } catch {
+      fromCache = true;
     }
+    setOffline(fromCache);
   };
 
   useEffect(() => {
@@ -65,7 +73,7 @@ const AgendaPage: React.FC = () => {
   };
 
   return (
-    <div>
+    <div className="agenda-container">
       <h1>Agenda</h1>
       <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
         <input
@@ -87,6 +95,7 @@ const AgendaPage: React.FC = () => {
         <button type="submit" disabled={loading}>Ajouter</button>
       </form>
       {message && <p>{message}</p>}
+      {offline && <p>Lecture offline</p>}
       <ul>
         {events.map((ev) => (
           <li key={ev.id}>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,15 @@ export default function RootLayout({
 }) {
   return (
     <html lang="fr">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#141414" />
+        <link
+          rel="apple-touch-icon"
+          href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottQAAAABJRU5ErkJggg=="
+        />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,11 @@
+export const metadata = { title: 'Pas de connexion' };
+
+export default function OfflinePage() {
+  return (
+    <div>
+      <h1>Pas de connexion</h1>
+      <p>Les données locales restent accessibles.</p>
+      <a href="/agenda">Aller à l'agenda</a>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import React, { useEffect, useState } from 'react';
-import Chat from '@/components/Chat';
+import Chat from '../components/Chat';
 
 const HomePage: React.FC = () => {
   const [name, setName] = useState('');

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -50,7 +50,7 @@ const Chat: React.FC = () => {
   const sendMessage = async (override?: string) => {
     const content = (override ?? input).trim();
     if (!content) return;
-    const newMessages = [...messages, { role: 'user', content }];
+    const newMessages: Message[] = [...messages, { role: 'user', content }];
     setMessages(newMessages);
     setInput('');
     setLoading(true);
@@ -75,7 +75,7 @@ const Chat: React.FC = () => {
         window.speechSynthesis.speak(u);
       }
     } catch {
-      const errMsg = 'Erreur de réseau.';
+      const errMsg = "Mode hors-ligne : l’IA distante est indisponible. Consultez ou ajoutez des événements dans l’Agenda.";
       setMessages((prev) => [...prev, { role: 'assistant', content: errMsg }]);
       if (typeof window !== 'undefined' && window.speechSynthesis) {
         const u = new SpeechSynthesisUtterance(errMsg);
@@ -110,7 +110,7 @@ const Chat: React.FC = () => {
   };
 
   return (
-    <div className="chat-wrapper">
+    <div className="chat-wrapper chat-container">
       <div style={{ marginBottom: '0.5rem' }}>
         <a href="/agenda">Voir l'agenda</a> | <a href="/settings">Paramètres</a>
       </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -62,3 +62,17 @@ code {
 .chat-form input {
   flex: 1;
 }
+
+@media (max-width: 600px) {
+  .chat-container,
+  .agenda-container {
+    width: 100%;
+    max-width: none;
+    padding: 0 1rem;
+  }
+  button,
+  input,
+  textarea {
+    min-height: 44px;
+  }
+}

--- a/tests/pwa.spec.ts
+++ b/tests/pwa.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from '@playwright/test';
+
+test('PWA manifest and service worker', async ({ page, context }) => {
+  await page.goto('/');
+  await expect(page.locator('link[rel="manifest"]')).toHaveCount(1);
+  const hasSW = await page.evaluate(() => 'serviceWorker' in navigator);
+  expect(hasSW).toBe(true);
+});


### PR DESCRIPTION
## Summary
- configure `next-pwa` with runtime caching and offline fallback
- déclarer le manifest JSON avec icônes en data URL
- intégrer les meta PWA dans le layout
- ajouter une page `/offline`
- améliorer Agenda et Chat pour la compatibilité hors‑ligne
- améliorer le responsive mobile
- ajouter un test Playwright minimal pour le PWA

## Testing
- `pytest -q`
- `npm run test:e2e`


------
https://chatgpt.com/codex/tasks/task_e_6889aefbee088321981b223c8db4bf6a