### PR TITLE
Add PWA support with next-pwa

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,28 @@
-/** @type {import('next').NextConfig} */
-const nextConfig = {
-  reactStrictMode: true,
-};
+const withPWA = require('next-pwa')({
+  dest: 'public',
+  register: true,
+  skipWaiting: true,
+  dynamicStartUrl: true,
+  runtimeCaching: [
+    {
+      urlPattern: /^\/_next\//,
+      handler: 'CacheFirst',
+    },
+    {
+      urlPattern: /^https:\/\/fonts\.(?:googleapis|gstatic)\.com\/.*$/i,
+      handler: 'CacheFirst',
+    },
+    {
+      urlPattern: /^\/api\/events/,
+      handler: 'NetworkFirst',
+      method: 'GET',
+    },
+  ],
+  fallbacks: {
+    html: '/offline',
+  },
+});
 
-module.exports = nextConfig;
+module.exports = withPWA({
+  reactStrictMode: true,
+});

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test:e2e": "playwright test"
   },
   "repository": {
     "type": "git",
@@ -20,5 +21,11 @@
   "bugs": {
     "url": "https://github.com/Mantinum/privus/issues"
   },
-  "homepage": "https://github.com/Mantinum/privus#readme"
+  "homepage": "https://github.com/Mantinum/privus#readme",
+  "dependencies": {
+    "next-pwa": "^5.6.0"
+  },
+  "devDependencies": {
+    "playwright": "^1.42.0"
+  }
 }

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,0 +1,15 @@
+// TODO: Remplacer ces data-URL par de vrais PNG dans un commit manuel ulterieur (pas dans cette PR).
+{
+  "name": "Privus \u2013 Assistant IA",
+  "short_name": "Privus",
+  "start_url": "/",
+  "display": "standalone",
+  "theme_color": "#141414",
+  "background_color": "#141414",
+  "orientation": "portrait",
+  "icons": [
+    { "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottQAAAABJRU5ErkJggg==", "sizes": "192x192", "type": "image/png" },
+    { "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottQAAAABJRU5ErkJggg==", "sizes": "256x256", "type": "image/png" },
+    { "src": "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottQAAAABJRU5ErkJggg==", "sizes": "512x512", "type": "image/png" }
+  ]
+}

--- a/src/app/agenda/page.tsx
+++ b/src/app/agenda/page.tsx
@@ -22,6 +22,9 @@ const AgendaPage: React.FC = () => {
     if (res.ok) {
       const data = await res.json();
       setEvents(data.events || []);
+      if (!navigator.onLine) {
+        setMessage('Lecture offline');
+      }
     }
   };
 
@@ -65,7 +68,7 @@ const AgendaPage: React.FC = () => {
   };
 
   return (
-    <div>
+    <div className="agenda-container">
       <h1>Agenda</h1>
       <form onSubmit={handleSubmit} style={{ marginBottom: '1rem' }}>
         <input

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -13,6 +13,15 @@ export default function RootLayout({
 }) {
   return (
     <html lang="fr">
+      <head>
+        <meta name="viewport" content="width=device-width, initial-scale=1" />
+        <link rel="manifest" href="/manifest.json" />
+        <meta name="theme-color" content="#141414" />
+        <link
+          rel="apple-touch-icon"
+          href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottQAAAABJRU5ErkJggg=="
+        />
+      </head>
       <body>{children}</body>
     </html>
   );

--- a/src/app/offline/page.tsx
+++ b/src/app/offline/page.tsx
@@ -1,0 +1,15 @@
+'use client'
+
+import React from 'react';
+
+const OfflinePage: React.FC = () => (
+  <div>
+    <h1>Pas de connexion</h1>
+    <p>Les données locales restent accessibles.</p>
+    <a href="/agenda">
+      <button>Ouvrir l'agenda</button>
+    </a>
+  </div>
+);
+
+export default OfflinePage;

--- a/src/components/Chat.tsx
+++ b/src/components/Chat.tsx
@@ -75,7 +75,8 @@ const Chat: React.FC = () => {
         window.speechSynthesis.speak(u);
       }
     } catch {
-      const errMsg = 'Erreur de réseau.';
+      const errMsg =
+        "Mode hors-ligne : l\u2019IA distante est indisponible. Consultez ou ajoutez des \u00e9v\u00e9nements dans l\u2019Agenda.";
       setMessages((prev) => [...prev, { role: 'assistant', content: errMsg }]);
       if (typeof window !== 'undefined' && window.speechSynthesis) {
         const u = new SpeechSynthesisUtterance(errMsg);
@@ -110,7 +111,7 @@ const Chat: React.FC = () => {
   };
 
   return (
-    <div className="chat-wrapper">
+    <div className="chat-wrapper chat-container">
       <div style={{ marginBottom: '0.5rem' }}>
         <a href="/agenda">Voir l'agenda</a> | <a href="/settings">Paramètres</a>
       </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -62,3 +62,17 @@ code {
 .chat-form input {
   flex: 1;
 }
+
+@media (max-width: 600px) {
+  .chat-container,
+  .agenda-container {
+    width: 100%;
+    max-width: none;
+    padding: 0 1rem;
+  }
+  button,
+  input,
+  textarea {
+    min-height: 44px;
+  }
+}

--- a/tests/pwa.spec.ts
+++ b/tests/pwa.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from 'playwright/test';
+
+test('manifest and service worker', async ({ page, context }) => {
+  await page.goto('/');
+  const manifest = await page.$('link[rel="manifest"]');
+  expect(manifest).not.toBeNull();
+  await page.waitForTimeout(1000); // allow sw to register
+  const workers = context.serviceWorkers();
+  expect(workers.length).toBeGreaterThan(0);
+});


### PR DESCRIPTION
## Summary
- enable next-pwa in `next.config.js`
- add manifest.json with placeholder icons
- update layout with PWA meta tags
- add offline fallback page
- make chat and agenda responsive
- display offline notices in chat and agenda
- add Playwright test for PWA setup

## Testing
- `npm install`
- `pytest -q`
- `npx playwright install --with-deps`
- `npm run test:e2e` *(fails: Cannot navigate to invalid URL)*

------
https://chatgpt.com/codex/tasks/task_e_6889aefbee088321981b223c8db4bf6a